### PR TITLE
Point to a new 'bundle' for JEDI based AQ DA

### DIFF
--- a/components/RRFS-CMAQ-DA/Externals.cfg
+++ b/components/RRFS-CMAQ-DA/Externals.cfg
@@ -1,8 +1,8 @@
-[jedi-fv3-bundle]
+[jedi-rrfs-cmaq-bundle]
 protocol = git
-repo_url = https://github.com/JCSDA/fv3-bundle
+repo_url = https://github.com/CoryMartin-NOAA/RRFS-DA-bundle
 # Specify either a branch name or a hash but not both.
-branch = develop
+branch = no2_Apr2022
 local_path = src/JEDI
 required = True
 


### PR DESCRIPTION
Instead of using FV3-bundle which will always grab develop, we can control specific commits that are checked out with this method by modifying the CMakeLists.txt file in  https://github.com/CoryMartin-NOAA/RRFS-DA-bundle