### PR TITLE
Adding NA/793 domain example for aqm_canopy

### DIFF
--- a/ush/sample_config/EMC_run/config.yaml_canopy_nco_aqmna13km_1day_hera
+++ b/ush/sample_config/EMC_run/config.yaml_canopy_nco_aqmna13km_1day_hera
@@ -1,0 +1,91 @@
+metadata:
+  description: config for Online-CMAQ, AQM_NA_13km, NCO mode, 1cycle a day
+user:
+  RUN_ENVIR: nco
+  MACHINE: hera
+  ACCOUNT: naqfc
+workflow:
+  USE_CRON_TO_RELAUNCH: true
+  CRON_RELAUNCH_INTVL_MNTS: 3
+#  EXPT_BASEDIR: /scratch2/NCEPDEV/stmp3/Chan-hoo.Jeon/expt_dirs
+  EXPT_SUBDIR: aqm.v7.0.c7
+  CCPP_PHYS_SUITE: FV3_GFS_v16
+  DATE_FIRST_CYCL: '20200915'
+  DATE_LAST_CYCL: '20200915'
+  CYCL_HRS:
+    - 12
+  FCST_LEN_HRS: 6
+  PREEXISTING_DIR_METHOD: rename
+  VERBOSE: true
+  COMPILER: intel
+  DIAG_TABLE_TMPL_FN: diag_table_aqm
+  FIELD_TABLE_TMPL_FN: field_table_aqm
+nco:
+  NET: aqm
+  model_ver: v7.0
+  RUN: aqm_test
+  OPSROOT: /scratch2/NCEPDEV/stmp3/Chan-hoo.Jeon/NCO_OUTPUT
+workflow_switches:
+  RUN_TASK_MAKE_GRID: false
+  RUN_TASK_MAKE_OROG: false
+  RUN_TASK_MAKE_SFC_CLIMO: false
+  RUN_TASK_RUN_POST: true
+task_make_grid:
+  GRID_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/DOMAIN_DATA/AQM_NA_13km
+task_make_orog:
+  OROG_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/DOMAIN_DATA/AQM_NA_13km
+task_make_sfc_climo:
+  SFC_CLIMO_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/DOMAIN_DATA/AQM_NA_13km
+task_get_extrn_ics:
+  EXTRN_MDL_NAME_ICS: FV3GFS
+#  FV3GFS_FILE_FMT_ICS: grib2
+task_get_extrn_lbcs:
+  EXTRN_MDL_NAME_LBCS: FV3GFS
+  LBC_SPEC_INTVL_HRS: 6
+#  FV3GFS_FILE_FMT_LBCS: grib2
+task_run_fcst:
+  DT_ATMOS: 180
+  LAYOUT_X: 50
+  LAYOUT_Y: 34
+  BLOCKSIZE: 16
+  RESTART_INTERVAL: 12
+  WTIME_RUN_FCST: 02:00:00
+  QUILTING: true
+  PRINT_ESMF: false
+  PREDEF_GRID_NAME: AQM_NA_13km
+task_run_post:
+  POST_OUTPUT_DOMAIN_NAME: 793
+global:
+  DO_ENSEMBLE: false
+  NUM_ENS_MEMBERS: 2
+  HALO_BLEND: 0
+cpl_aqm_parm:
+  CPL_AQM: true
+  RUN_TASK_ADD_AQM_ICS: true
+  RUN_TASK_ADD_AQM_LBCS: true
+  RUN_TASK_RUN_NEXUS: true
+  RUN_ADD_AQM_CHEM_LBCS: true
+  RUN_ADD_AQM_GEFS_LBCS: true
+  AQM_GEFS_CYC: 0
+  AQM_RC_TMPL_FN: aqm.rc
+  AQM_CONFIG_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/aqm/epa/data
+  AQM_BIO_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/aqm/bio
+  AQM_BIO_FILE: BEIS_RRFScmaq_C775.ncf
+  AQM_FENGSHA_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/FENGSHA
+  AQM_FENGSHA_FILE_PREFIX: FENGSHA_p8_10km_inputs
+  AQM_FENGSHA_FILE_SUFFIX: .nc
+  AQM_CANOPY_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/canopy/793
+  AQM_CANOPY_FILE: gfs.t12z.geo
+  AQM_CANOPY_FILE_SUFFIX: .canopy_regrid.nc
+  AQM_FIRE_DIR: /scratch2/NCEPDEV/naqfc/Jianping.Huang/Data/emissions/GSCE/RAVE.in.793/RAVE_RT
+  AQM_FIRE_FILE: Hourly_Emissions_regrid_NA_13km
+  AQM_FIRE_FILE_SUFFIX: _h72.nc
+  AQM_RC_FIRE_FREQUENCY: hourly
+  AQM_LBCS_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ_NA13km/LBCS/RRFS_NA13km_GEOS5_v2
+  AQM_LBCS_FILES: geos5_bndy_v2.c793.2013<MM>.nc
+  AQM_GEFS_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/GEFS_aerosol
+  NEXUS_INPUT_DIR: /scratch2/NCEPDEV/naqfc/Jianping.Huang/emissions/nexus
+  NEXUS_FIX_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/nexus/fix
+  NEXUS_GRID_FN: grid_spec_793.nc
+  RESTART_WORKFLOW: true
+  RESTART_CYCLE_DIR: /scratch2/NCEPDEV/stmp3/Jianping.Huang/NCO_OUTPUT/stmp/tmpnwprd/aqm_test_a/2020091412

--- a/ush/sample_config/EMC_run/config.yaml_canopy_rrfsconus13km_1day_hera
+++ b/ush/sample_config/EMC_run/config.yaml_canopy_rrfsconus13km_1day_hera
@@ -60,7 +60,7 @@ cpl_aqm_parm:
   AQM_CONFIG_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/aqm/epa/data
   AQM_BIO_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/aqm/bio
   AQM_BIO_FILE: BEIS_RRFScmaq_C775.ncf
-  AQM_CANOPY_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/canopy
+  AQM_CANOPY_DIR: /scratch2/NCEPDEV/naqfc/RRFS_CMAQ/canopy/CONUS13km
   AQM_CANOPY_FILE: gfs.t12z.geo
   AQM_CANOPY_FILE_SUFFIX: .canopy_regrid.nc
   AQM_FIRE_DIR: /scratch2/NCEPDEV/naqfc/Jianping.Huang/Data/emissions/GSCE/GBBEPx.in.C775/Reprocessed


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Adding sample config file for the NA 793 online-cmaq domain in preparation for upcoming pull request to AQM component in the ufs-weather-model for canopy effects.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:

## DOCUMENTATION:

## ISSUE: 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ X] My changes do not require updates to the documentation (explain).
Just a sample config update for NA domain.
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
- [X ] Work In Progress
- [ ] bug
- [ X] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 


