### PR TITLE
[feature/add_sd] Update TechDocs/ush to allow for the TechDocs to pass

### DIFF
--- a/doc/TechDocs/ush/smoke_dust_add_smoke.rst
+++ b/doc/TechDocs/ush/smoke_dust_add_smoke.rst
@@ -1,5 +1,5 @@
 smoke\_dust\_add\_smoke module
-================
+==============================
 
 .. automodule:: smoke_dust_add_smoke
    :members:

--- a/doc/TechDocs/ush/smoke_dust_fire_emiss_tools.rst
+++ b/doc/TechDocs/ush/smoke_dust_fire_emiss_tools.rst
@@ -1,5 +1,5 @@
 smoke\_dust\_fire\_emiss\_tools module
-================
+======================================
 
 .. automodule:: smoke_dust_fire_emiss_tools
    :members:

--- a/doc/TechDocs/ush/smoke_dust_generate_fire_emissions.rst
+++ b/doc/TechDocs/ush/smoke_dust_generate_fire_emissions.rst
@@ -1,5 +1,5 @@
 smoke\_dust\_generate\_fire\_emissions module
-================
+=============================================
 
 .. automodule:: smoke_dust_generate_fire_emissions
    :members:

--- a/doc/TechDocs/ush/smoke_dust_hwp_tools.rst
+++ b/doc/TechDocs/ush/smoke_dust_hwp_tools.rst
@@ -1,5 +1,5 @@
 smoke\_dust\_hwp\_tools module
-================
+==============================
 
 .. automodule:: smoke_dust_hwp_tools
    :members:

--- a/doc/TechDocs/ush/smoke_dust_interp_tools.rst
+++ b/doc/TechDocs/ush/smoke_dust_interp_tools.rst
@@ -1,5 +1,5 @@
 smoke\_dust\_interp\_tools module
-================
+=================================
 
 .. automodule:: smoke_dust_interp_tools
    :members:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The `Doc Tests` GitHub Action was failing due to modifications made to the new `TechDocs/ush` rst files while running the action.  The rst files have been updated to allow the `Doc Tests` to successfully pass the TechDocs part of the test.

Please note, that due to the expiration of the security certificate with `https://www.fvcom.org`, the test will fail while attempting to add this link, resulting in the failure of the `Doc Tests`, but this is currently expected.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
The `Doc Tests` fails as expected in `Build documentation` rather than `Check tech docs`, as can be seen [here](https://github.com/MichaelLueken/ufs-srweather-app/actions/runs/13033687796/job/36358715227).

## DOCUMENTATION:
The TechDocs/ush rst files have been updated.

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings